### PR TITLE
Fix imports, update readme install, and rearrange .env var order

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,17 @@ An awesome python script to automate bing searches, quizes, polls, and more acro
 - Apprise Alerts
 - Streak Notifications
 
-
-## Demo
-
-{coming soon}
-
 ## Installation
-### - Install the following dependencies using pip3:
-```sh
-   pip3 install RandomWords
-   pip3 install Selenium
-   pip3 install apprise
-   pip3 install python-dotenv
-   pip3 install pytz
-   ```
-Alternatively, you can clone this repository and install using requirements.txt
+The bot can be run using Python or Docker.
+### Python Script
+1. Clone this repository, cd into it, and install dependancies:
 ```sh
    git clone https://github.com/sazncode/BingRewards.git
    cd Bing-Rewards
-   pip3 install -r requirements.txt
+   pip install -r requirements.txt
    ```
-### - Start the program
+2. Configure your `.env` file (See below and example for options)
+3. Run the script:
 ```sh
    python main.py
 ```
@@ -39,22 +29,25 @@ Alternatively, you can clone this repository and install using requirements.txt
 ### Docker Container
 View on [Docker Hub](https://hub.docker.com/repository/docker/nelsondane/bing-rewards)
 1. Download and install Docker on your system
-2. Run: `docker run -it --env-file ./.env --restart unless-stopped --name bing-rewards nelsondane/bing-rewards:<tag>`. This creates a new container called bing-rewards. Make sure you have the correct path to your `.env` file you created.
+2. Configure your `.env` file (See below and example for options)
+3. Start the bot using Docker Run:
+ ```sh
+   docker run -it --env-file ./.env --restart unless-stopped --name bing-rewards nelsondane/bing-rewards:<tag>
+   ```
+   This creates a new container called bing-rewards. Make sure you have the correct path to your `.env` file you created.
 
-Let the bot log in, this could take a minute. Make sure the bot logs in correctly: wait until it prints your email and points. DO NOT PRESS CTRL-C. This will kill the container. To exit the logs view, press CTRL-p then CTRL-q. This will exit the logs view but let the bot keep running.
+4. Let the bot log in and begin working. DO NOT PRESS CTRL-c. This will kill the container and the bot. To exit the logs view, press CTRL-p then CTRL-q. This will exit the logs view but let the bot keep running.
 
 ### Available Docker Tags
 Replace the `<tag>` above with one of these (defaults to `latest`)
 - `latest`: latest stable release on [Sazn's GitHub](https://github.com/sazncode/Bing-Rewards)
 - `beta`: latest beta release on [NelsonDane's GitHub](https://github.com/NelsonDane/Bing-Rewards)
 
-
-
 ## Environment Variables:
 
-To run this project, you will need to add the following environment variables to your .env file. 
+To run this project, you will need to add the following environment variables to your `.env` file. 
 
-`LOGIN` = A string of Bing Rewards login information. Email and Password are seperated using a colon and accounts are seperated using commas. Check .env.example file for an example.
+`LOGIN` = A string of Bing Rewards login information. Email and Password are seperated using a colon and accounts are seperated using commas. Check `.env.example` for how an example.
 
 `URL` = Sign in link obtained through https://bing.com/
 
@@ -64,23 +57,16 @@ To run this project, you will need to add the following environment variables to
 
 `APPRISE_ALERTS` = Notifications and Alerts. See .env example for more details
 
-
 `WANTED_IPV4` = Your desired external IPV4 address. Set this if you want the bot to not run if your IPv4 address is different than this.
 
 `WANTED_IPV6` = Your desired external IPv6 address. Set this if you want the bot to not run if your IPv6 address is different than this.
 
 `PROXY` = Configure a HTTP(S) or SOCKS5 proxy through which all of the bot's traffic will go. Should be in a URI format (e.g., https://1.2.3.4:5678)
 
-
 `TZ` = Your desired Time-Zone. Defaults to America/New York
 
 `TIMER` = True or False. Whether you wish for the program to only run between certain time period.
 
-   `START_TIME` = 24 hour format hour you would like to start the program, if timer is enabled. Defaults to 4, 4 AM
+`START_TIME` = 24 hour format hour you would like to start the program, if timer is enabled. Defaults to 4, 4 AM
 
-   `END_TIME` = 24 hour format hour you would like to start the program, if timer is enabled. Defaults to 23, 11 PM
-
-
-
-
-
+`END_TIME` = 24 hour format hour you would like to start the program, if timer is enabled. Defaults to 23, 11 PM

--- a/main.py
+++ b/main.py
@@ -23,9 +23,11 @@ except ImportError:
         from random_words import RandomWords
     except ImportError:
         os.system("pip3 install RandomWords")
-        from random_words import RandomWords
-        pass
-    pass
+        try:
+            from random_words import RandomWords
+        except:
+            print("Unable to import RandomWords")
+            raise Exception
 # Apprise
 try:
     import apprise
@@ -35,9 +37,11 @@ except ImportError:
         import apprise
     except ImportError:
         os.system("pip3 install apprise")
-        import apprise
-        pass
-    pass
+        try:
+            import apprise
+        except:
+            print("Unable to import apprise")
+            raise Exception
 # pytz
 try:
     from pytz import timezone
@@ -47,9 +51,11 @@ except ImportError:
         from pytz import timezone
     except ImportError:
         os.system("pip3 install pytz")
-        from pytz import timezone
-        pass
-    pass
+        try:
+            from pytz import timezone
+        except:
+            print("Unable to import pytz")
+            raise Exception
 
 # Load ENV
 load_dotenv()
@@ -460,7 +466,7 @@ def checkStreaks(driver, EMAIL):
                 alerts.notify(title=f'Bing Rewards {EMAIL} Streak Info', body=f'{bonusNotification}\n\n...')
     except:
         pass
-    
+
 def getDriver(isMobile = False):
     if not HANDLE_DRIVER:
         chrome_options = Options()

--- a/main.py
+++ b/main.py
@@ -13,23 +13,55 @@ from selenium.common.exceptions import NoSuchElementException
 from time import sleep
 from dotenv import load_dotenv
 
+# In case imports fail, retry using pip and pip3
+# RandomWords
 try:
     from random_words import RandomWords
 except ImportError:
-    os.system("pip3 install RandomWords")
-    from random_words import RandomWords
+    os.system("pip install RandomWords")
+    try:
+        from random_words import RandomWords
+    except ImportError:
+        os.system("pip3 install RandomWords")
+        from random_words import RandomWords
+        pass
+    pass
+# Apprise
+try:
+    import apprise
+except ImportError:
+    os.system("pip3 install apprise")
+    try:
+        import apprise
+    except ImportError:
+        os.system("pip3 install apprise")
+        import apprise
+        pass
+    pass
+# pytz
+try:
+    from pytz import timezone
+except ImportError:
+    os.system("pip install pytz")
+    try:
+        from pytz import timezone
+    except ImportError:
+        os.system("pip3 install pytz")
+        from pytz import timezone
+        pass
     pass
 
 # Load ENV
 load_dotenv()
 
+# LOGIN EXAMPLE:
+# "EMAIL:PASSWORD,EMAIL:PASSWORD"
 if not os.environ["LOGIN"]:
     raise Exception("LOGIN not set. Please enter your login information in .env variable 'LOGIN' in the following format: 'EMAIL:PASSWORD,EMAIL2:PASSWORD2,EMAIL3:PASSWORD3'")
 else:
-    # LOGIN EXAMPLE:
-    # "EMAIL:PASSWORD,EMAIL:PASSWORD"
     ACCOUNTS = os.environ["LOGIN"].replace(" ", "").split(",")
 
+# Check number of accounts (limit to 5 per IP address to avoid bans)
 if (len(ACCOUNTS) > 5):
     raise Exception(f"You can only have 5 accounts per IP address. Using more increases your chances of being banned by Microsoft Rewards. You have {len(ACCOUNTS)} accounts within your LOGIN env variable. Please adjust it to have 5 or less accounts and restart the program.")
 
@@ -41,18 +73,8 @@ TERMS = ["define ", "explain ", "example of ", "how to pronounce ", "what is ", 
         "what is the antonym of ", "what is the hypernym of ", "what is the meronym of ","photos of "]
 
 # Optional Variables
-APPRISE_ALERTS = os.environ.get("APPRISE_ALERTS", "")
-if APPRISE_ALERTS:
-    APPRISE_ALERTS = APPRISE_ALERTS.split(",")
-    try:
-        import apprise
-    except ImportError:
-        os.system("pip3 install apprise")
-        import apprise
-        pass
-
+# Whether to use the chromewebdriver or not
 HANDLE_DRIVER = os.environ.get("HANDLE_DRIVER", "False")
-
 if (HANDLE_DRIVER.lower() == "true"):
     HANDLE_DRIVER = True
     from webdriver_manager.chrome import ChromeDriverManager
@@ -60,14 +82,26 @@ if (HANDLE_DRIVER.lower() == "true"):
 else:
     HANDLE_DRIVER = False
 
-try:
-    from pytz import timezone
-except ImportError:
-    os.system("pip3 install pytz")
-    from pytz import timezone
-    pass
+# Apprise Alerts
+APPRISE_ALERTS = os.environ.get("APPRISE_ALERTS", "")
+if APPRISE_ALERTS:
+    APPRISE_ALERTS = APPRISE_ALERTS.split(",")
+
+# Get IPs if it's set in .env
+wanted_ipv4 = os.environ.get("WANTED_IPV4")
+wanted_ipv6 = os.environ.get("WANTED_IPV6")
+
+# Get proxy settings from .env
+# Note that we should set '' instead of None in case PROXY is not defined to prevent the proxies dict below from being invalid (which breaks our IP checker)
+proxy = os.environ.get("PROXY", "")
+
+# Populate proxy dictionary for requests
+proxies = {"http": f"{proxy}", "https": f"{proxy}"}
+
+# Configure timezone
 TZ = timezone(os.environ.get("TZ", "America/New_York"))
 
+# Whether or not to use a timer, and if so, what time to use
 TIMER = os.environ.get("TIMER", "False")
 if TIMER.lower() == "true":
     TIMER = True
@@ -84,19 +118,6 @@ if TIMER.lower() == "true":
 else:
     TIMER = False
 
-
-# Get IPs if it's set in .env
-wanted_ipv4 = os.environ.get("WANTED_IPV4")
-wanted_ipv6 = os.environ.get("WANTED_IPV6")
-
-# Get proxy settings from .env
-# Note that we should set '' instead of None in case PROXY is not defined to prevent the proxies dict below from being invalid (which breaks our IP checker)
-proxy = os.environ.get("PROXY", "")
-
-# Populate proxy dictionary for requests
-proxies = {"http": f"{proxy}", "https": f"{proxy}"}
-
-
 # Methods
 def apprise_init():
     if APPRISE_ALERTS:
@@ -105,6 +126,7 @@ def apprise_init():
         for service in APPRISE_ALERTS:
             alerts.add(service)
         return alerts
+
 def wait():
     if not datetime.datetime.now(TZ).hour >= START_TIME and datetime.datetime.now(TZ).hour <= END_TIME:
         range = abs((START_TIME - datetime.datetime.now(TZ).hour))
@@ -214,7 +236,6 @@ def login(EMAIL, PASSWORD, driver):
     
     driver.find_element(By.XPATH, value='//*[@id="idSIButton9"]').click()
     return True
-    
 
 def completeSet(driver):
     sleep(random.uniform(10, 15))
@@ -245,6 +266,7 @@ def completePoll(driver):
         pass
     sleep(3)
     return
+
 # TODO: Clean up code
 def completeQuiz(driver):
     sleep(random.uniform(7, 14))
@@ -299,6 +321,7 @@ def completeQuiz(driver):
         except Exception as e:
             print(e)
             pass
+
 # TODO: Clean up code
 def completeMore(driver):
     ran = False
@@ -369,6 +392,7 @@ def completeMore(driver):
         print(traceback.format_exc())
         pass
     return ran
+
 # TODO: Clean up code
 def dailySet(driver):
         ranSets = False
@@ -420,6 +444,7 @@ def dailySet(driver):
             pass
 
         return ranSets
+
 def checkStreaks(driver, EMAIL):
     try:
         driver.get('https://rewards.microsoft.com/')
@@ -435,6 +460,7 @@ def checkStreaks(driver, EMAIL):
                 alerts.notify(title=f'Bing Rewards {EMAIL} Streak Info', body=f'{bonusNotification}\n\n...')
     except:
         pass
+    
 def getDriver(isMobile = False):
     if not HANDLE_DRIVER:
         chrome_options = Options()


### PR DESCRIPTION
if an import fails, then it is retried using `pip`, and if that fails then it falls back to `pip3`. If both fail, then raise exception. Also rearranged env variable declaration so that they are declared in the order that they are in `.env.example`. Updated the readme install instructions so that they were clearer and easier to follow