### PR TITLE
Join rewards on first run

### DIFF
--- a/main.py
+++ b/main.py
@@ -532,8 +532,14 @@ def getPoints(EMAIL, PASSWORD, driver):
                 join_rewards.click()
                 print(f'Joined microsoft rewards on account {EMAIL}')
             except:
+                print(traceback.format_exc())
                 print("Got rewards welcome page, but couldn't join rewards.")
                 return -404
+            try:
+                if driver.current_url == 'https://rewards.microsoft.com/welcometour':
+                    driver.find_element(By.XPATH, value='//*[@id="welcome-tour"]/mee-rewards-slide/div/section/section/div/a[2]').click()
+            except:
+                driver.get('https://rewards.microsoft.com/')
         if driver.title.lower() == 'rewards error':
             sleep(random.uniform(2, 4))
             driver.get('https://rewards.microsoft.com/')

--- a/main.py
+++ b/main.py
@@ -522,6 +522,18 @@ def getPoints(EMAIL, PASSWORD, driver):
         driver.get('https://rewards.microsoft.com/Signin?idru=%2F')
         if not login(EMAIL, PASSWORD, driver):
             return -404
+        # If it's the first sign in, join microsoft rewards
+        if driver.current_url == 'https://rewards.microsoft.com/welcome':
+            try:
+                join_rewards = driver.find_element(By.XPATH, value='//*[@id="start-earning-rewards-link"]')
+                WebDriverWait(driver, 10).until(
+                    EC.element_to_be_clickable(join_rewards)
+                )
+                join_rewards.click()
+                print(f'Joined microsoft rewards on account {EMAIL}')
+            except:
+                print("Got rewards welcome page, but couldn't join rewards.")
+                return -404
         if driver.title.lower() == 'rewards error':
             sleep(random.uniform(2, 4))
             driver.get('https://rewards.microsoft.com/')


### PR DESCRIPTION
If the bing rewards page redirects to `rewards.microsoft.com/welcome` then that means the account hasn't joined bing rewards yet. This adds a check so that if the page url is equal to the above, it will click the join rewards button, in which case it will then run successfully.