### PR TITLE
Set user agent to edge when getting Driver

### DIFF
--- a/main.py
+++ b/main.py
@@ -503,6 +503,10 @@ def getDriver(isMobile = False):
         mobile_emulation = {"deviceName": "Nexus 5"}
         chrome_options.add_experimental_option(
             "mobileEmulation", mobile_emulation)
+    else:
+        # Set edge user agent if not mobile
+        user_agent = "mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36 (khtml, like gecko) chrome/64.0.3282.140 safari/537.36 edge/18.17763"
+        chrome_options.add_argument(f'user-agent={user_agent}')
 
     if not HANDLE_DRIVER:
         driver = webdriver.Chrome(options=chrome_options)

--- a/main.py
+++ b/main.py
@@ -504,11 +504,9 @@ def getDriver(isMobile = False):
         chrome_options.add_experimental_option(
             "mobileEmulation", mobile_emulation)
     else:
-        # Set edge user agent if not mobile
+        # Set to edge user agent if not mobile
         user_agent = "mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36 (khtml, like gecko) chrome/64.0.3282.140 safari/537.36 edge/18.17763"
         chrome_options.add_argument(f'user-agent={user_agent}')
-        # For testing
-        print(f"Set Chrome user agent to {user_agent}")
 
     if not HANDLE_DRIVER:
         driver = webdriver.Chrome(options=chrome_options)

--- a/main.py
+++ b/main.py
@@ -507,6 +507,8 @@ def getDriver(isMobile = False):
         # Set edge user agent if not mobile
         user_agent = "mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36 (khtml, like gecko) chrome/64.0.3282.140 safari/537.36 edge/18.17763"
         chrome_options.add_argument(f'user-agent={user_agent}')
+        # For testing
+        print(f"Set Chrome user agent to {user_agent}")
 
     if not HANDLE_DRIVER:
         driver = webdriver.Chrome(options=chrome_options)


### PR DESCRIPTION
By user agent spoofing, Bing searches on Edge can be completed. This adds the user agent chrome argument in order to change the user agent to Edge whenever a new desktop driver is created. It does not do it on mobile emulation however since that caused issues.