### PR TITLE
Update ignore, readme, docker entrypoint, and clean extraneous code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ URL="SIGN IN LINK FROM https://bing.com"
 # Optional .env variables:
 
 HANDLE_DRIVER= True or False. Set WebDriver Download Manager On (True, no env variable necessary) or off (False)
-BROWSER= 'edge' or 'firefox' -- Browser you would like to use the bot with. In experimental mode. HANDLE_DRIVER must be set to True to use.
+BROWSER= 'chrome', 'edge' or 'firefox' -- Browser you would like to use the bot with. In experimental mode. HANDLE_DRIVER must be set to True to use. Defaults to Chrome.
 
 APPRISE_ALERTS= configure apprise URL alerts, seperating each URL with a comma. Full list of services and their URLs available here: https://github.com/caronc/apprise/wiki
 
@@ -27,7 +27,7 @@ PROXY=
 
 BOT_NAME = Name of instance of bot: 'bing rewards 2' or 'docker proxy 2'
 
-TZ= EST (defaults to America/New York)
+TZ= EST (defaults to America/New York, see README for more info)
 TIMER=True or False
 START_TIME=4
 END_TIME=20

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .vscode/
+geckodriver.log
+test.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 .env
 .vscode/
-.github/
-geckodriver.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .vscode/
+.github/
+geckodriver.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   python3 \ 
   python3-pip \
+  firefox \
   xvfb \
   xfonts-cyrillic \
   xfonts-100dpi \
@@ -22,11 +23,6 @@ RUN apt-get update && apt-get install -y \
   xfonts-scalable \
   gtk2-engines-pixbuf \
 && rm -rf /var/lib/apt/lists/*
-
-# Download and install Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-RUN apt-get update && apt-get -y install google-chrome-stable && rm -rf /var/lib/apt/lists/*
 
 # Install bot Python deps
 ADD ./requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y \
   gpg \
   python3 \ 
   python3-pip \
-  firefox \
   xvfb \
   xfonts-cyrillic \
   xfonts-100dpi \
@@ -23,6 +22,11 @@ RUN apt-get update && apt-get install -y \
   xfonts-scalable \
   gtk2-engines-pixbuf \
 && rm -rf /var/lib/apt/lists/*
+
+# Download and install Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+RUN apt-get update && apt-get -y install google-chrome-stable && rm -rf /var/lib/apt/lists/*
 
 # Install bot Python deps
 ADD ./requirements.txt .

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The bot can be run using Python or Docker.
 1. Clone this repository, cd into it, and install dependancies:
 ```sh
    git clone https://github.com/sazncode/BingRewards.git
-   cd Bing-Rewards
+   cd BingRewards
    pip install -r requirements.txt
    ```
 2. Configure your `.env` file (See below and example for options)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run this project, you will need to add the following environment variables to
 
 `HANDLE_DRIVER` = Boolean (True/False) variable based on whether a user wants webdriver to be installed for them. Defaultly set to True.
 
-`BROWSER` = 'edge' or 'firefox' -- Browser you'd like to use the bot with. In experimental mode. HANDLE_DRIVER must be set to True to use.
+`BROWSER` = `chrome`, `edge`, or `firefox` -- Browser you'd like to use the bot with. In experimental mode. `HANDLE_DRIVER` must be set to True to use. Defaults to `chrome`.
 
 `APPRISE_ALERTS` = Notifications and Alerts. See .env example for more details
 
@@ -87,7 +87,7 @@ To run this project, you will need to add the following environment variables to
 
 `PROXY` = Configure a HTTP(S) or SOCKS5 proxy through which all of the bot's traffic will go. Should be in a URI format (e.g., https://1.2.3.4:5678)
 
-`TZ` = Your desired Time-Zone. Defaults to America/New York
+`TZ` = Your desired Time-Zone. Should be formatted from the [IANA TZ Database](https://www.iana.org/time-zones). Defaults to `America/New York`
 
 `TIMER` = True or False. Whether you wish for the program to only run between certain time period.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,7 @@ rm /tmp/.X99-lock
 echo "Starting X virtual framebuffer (Xvfb) in background..."
 Xvfb -ac :99 -screen 0 1280x1024x16 &
 export DISPLAY=:99
+echo "BROWSER: $BROWSER"
+echo "HANDLE_DRIVER: $HANDLE_DRIVER"
 echo "Starting Bing Rewards Bot..."
 python3 main.py


### PR DESCRIPTION
This PR adds `test.py` and the Firefox gecko driver logs to the `gitignore` file. It also adds information about the browser `env` setting in the readme and example files, such as the default value. It also adds a link in the readme and example so that users can know how to format their timezone variable `TZ`.

In the Docker `entrypoint.sh` file, the `BROWSER` and `HANDLE_DRIVER` values are now printed along with the starting messages.

In `main.py`, a single `.lower()` is added when certain `env` variables are imported. This way `.lower()` isn't needed every single time the variable is called to be compared with a value. `URL` is also now imported from the environment only at the beginning of the script along with the other `.env` variables instead of multiple times inside of the methods.